### PR TITLE
fix: Policy violation remediation in demo-remediator-main/apps/nginx/deployment.yaml

### DIFF
--- a/demo-remediator-main/apps/nginx/deployment.yaml
+++ b/demo-remediator-main/apps/nginx/deployment.yaml
@@ -4,7 +4,6 @@ metadata:
   name: nginx
   labels:
     app: nginx
-  annotations: {}
 spec:
   replicas: 1
   selector:

--- a/demo-remediator-main/apps/nginx/deployment.yaml
+++ b/demo-remediator-main/apps/nginx/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: nginx
   labels:
     app: nginx
+  annotations: {}
 spec:
   replicas: 1
   selector:

--- a/demo-remediator-main/apps/nginx/deployment.yaml
+++ b/demo-remediator-main/apps/nginx/deployment.yaml
@@ -4,8 +4,6 @@ metadata:
   name: nginx
   labels:
     app: nginx
-  annotations:
-    container.apparmor.security.beta.kubernetes.io/nginx: unconfined
 spec:
   replicas: 1
   selector:
@@ -18,15 +16,16 @@ spec:
     spec:
       volumes:
       - name: host-vol
-        hostPath:
-          path: /etc
+        emptyDir: {}
       containers:
       - name: nginx
         image: nginx:latest
         ports:
         - containerPort: 80
         securityContext:
-          privileged: true
-          capabilities:
-            add:
-            - SYS_ADMIN
+          privileged: false
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 1000
+          seccompProfile:
+            type: RuntimeDefault


### PR DESCRIPTION
## Policy Violation Remediation

**File:** demo-remediator-main/apps/nginx/deployment.yaml
**Explanation:** The following changes were made to comply with the Kyverno policies:

1. Removed the AppArmor annotation that was set to 'unconfined', which is a security risk.
2. Changed the hostPath volume to an emptyDir volume to comply with the 'restrict-volume-types' policy, which restricts the use of hostPath volumes.
3. Modified the security context to:
   - Set privileged: false (was true)
   - Remove the SYS_ADMIN capability to comply with 'disallow-capabilities-strict'
   - Add allowPrivilegeEscalation: false to comply with 'disallow-privilege-escalation'
   - Add runAsNonRoot: true and runAsUser: 1000 to comply with 'require-run-as-nonroot'
   - Add seccompProfile with type: RuntimeDefault to comply with 'restrict-seccomp-strict'

Additional improvement suggestions (not implemented):
- Consider specifying a specific version of nginx instead of using 'latest' tag
- Add resource limits and requests for the container
- Consider adding network policies to restrict traffic