### PR TITLE
fix: Policy violation remediation in demo-remediator-main/apps/nginx/deployment.yaml

### DIFF
--- a/demo-remediator-main/apps/nginx/deployment.yaml
+++ b/demo-remediator-main/apps/nginx/deployment.yaml
@@ -25,8 +25,8 @@ spec:
         - containerPort: 80
         securityContext:
           privileged: false
+          allowPrivilegeEscalation: false
           runAsNonRoot: true
           runAsUser: 1000
-          allowPrivilegeEscalation: false
           seccompProfile:
             type: RuntimeDefault

--- a/demo-remediator-main/apps/nginx/deployment.yaml
+++ b/demo-remediator-main/apps/nginx/deployment.yaml
@@ -25,8 +25,8 @@ spec:
         - containerPort: 80
         securityContext:
           privileged: false
-          allowPrivilegeEscalation: false
           runAsNonRoot: true
           runAsUser: 1000
+          allowPrivilegeEscalation: false
           seccompProfile:
             type: RuntimeDefault

--- a/demo-remediator-main/apps/nginx/deployment.yaml
+++ b/demo-remediator-main/apps/nginx/deployment.yaml
@@ -4,8 +4,7 @@ metadata:
   name: nginx
   labels:
     app: nginx
-  annotations:
-    container.apparmor.security.beta.kubernetes.io/nginx: unconfined
+  annotations: {}
 spec:
   replicas: 1
   selector:
@@ -18,15 +17,16 @@ spec:
     spec:
       volumes:
       - name: host-vol
-        hostPath:
-          path: /etc
+        emptyDir: {}
       containers:
       - name: nginx
         image: nginx:latest
         ports:
         - containerPort: 80
         securityContext:
-          privileged: true
-          capabilities:
-            add:
-            - SYS_ADMIN
+          privileged: false
+          runAsNonRoot: true
+          runAsUser: 1000
+          allowPrivilegeEscalation: false
+          seccompProfile:
+            type: RuntimeDefault


### PR DESCRIPTION
## Policy Violation Remediation

**File:** demo-remediator-main/apps/nginx/deployment.yaml
**Explanation:** The following changes were made to remediate policy violations:

1. Removed the unconfined AppArmor annotation which violates security best practices
2. Changed the hostPath volume to an emptyDir volume to comply with the restrict-volume-types policy
3. Modified the securityContext to:
   - Set privileged: false (was true)
   - Removed the SYS_ADMIN capability to comply with disallow-capabilities-strict
   - Added runAsNonRoot: true and runAsUser: 1000 to comply with require-run-as-nonroot
   - Added allowPrivilegeEscalation: false to comply with disallow-privilege-escalation
   - Added seccompProfile with type: RuntimeDefault to comply with restrict-seccomp-strict

Additional improvement suggestion (not implemented):
- Consider using a specific version tag for the nginx image instead of 'latest' for better stability and security