### PR TITLE
fix: Policy violation remediation in demo-remediator-main/apps/sample-app/deployment.yaml

### DIFF
--- a/demo-remediator-main/apps/sample-app/deployment.yaml
+++ b/demo-remediator-main/apps/sample-app/deployment.yaml
@@ -4,8 +4,6 @@ metadata:
   name: sample-app
   labels:
     app: sample-app
-  annotations:
-    container.apparmor.security.beta.kubernetes.io/sample-app: unconfined
 spec:
   replicas: 1
   selector:
@@ -18,15 +16,17 @@ spec:
     spec:
       volumes:
       - name: host-vol
-        hostPath:
-          path: /etc
+        emptyDir: {}
       containers:
       - name: sample-app
         image: nginx:latest
         ports:
         - containerPort: 80
         securityContext:
-          privileged: true
+          privileged: false
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 10001
           capabilities:
-            add:
-            - SYS_ADMIN
+            drop:
+            - ALL

--- a/demo-remediator-main/apps/sample-app/deployment.yaml
+++ b/demo-remediator-main/apps/sample-app/deployment.yaml
@@ -4,6 +4,8 @@ metadata:
   name: sample-app
   labels:
     app: sample-app
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/sample-app: runtime/default
 spec:
   replicas: 1
   selector:
@@ -16,7 +18,8 @@ spec:
     spec:
       volumes:
       - name: host-vol
-        emptyDir: {}
+        hostPath:
+          path: /etc
       containers:
       - name: sample-app
         image: nginx:latest
@@ -24,9 +27,9 @@ spec:
         - containerPort: 80
         securityContext:
           privileged: false
-          allowPrivilegeEscalation: false
           runAsNonRoot: true
-          runAsUser: 10001
+          runAsUser: 1000
+          allowPrivilegeEscalation: false
           capabilities:
             drop:
             - ALL


### PR DESCRIPTION
## Policy Violation Remediation

**File:** demo-remediator-main/apps/sample-app/deployment.yaml
**Explanation:** The following changes were made to remediate the resource:

1. Changed the AppArmor profile from 'unconfined' to 'runtime/default' to enforce container isolation.
2. Set 'privileged: false' to prevent privileged container execution.
3. Removed the SYS_ADMIN capability which is a high-risk capability.
4. Added 'runAsNonRoot: true' and 'runAsUser: 1000' to ensure the container runs as a non-root user.
5. Added 'allowPrivilegeEscalation: false' to prevent privilege escalation.
6. Changed capabilities configuration to drop ALL capabilities instead of adding dangerous ones.

Additional recommendations (not implemented):
1. Consider replacing the hostPath volume with a more secure volume type like emptyDir or a PVC, as hostPath volumes can be a security risk.
2. Use a specific image tag instead of 'latest' for better version control and security.
3. Add resource limits and requests to prevent resource exhaustion attacks.
4. Consider adding seccomp and SELinux configurations for additional security layers.