### PR TITLE
fix: Policy violation remediation in demo-remediator-main/apps/sample-app/deployment.yaml

### DIFF
--- a/demo-remediator-main/apps/sample-app/deployment.yaml
+++ b/demo-remediator-main/apps/sample-app/deployment.yaml
@@ -29,5 +29,5 @@ spec:
           seccompProfile:
             type: RuntimeDefault
           capabilities:
-            add:
-            - SYS_ADMIN
+            drop:
+            - ALL


### PR DESCRIPTION
## Policy Violation Remediation

**File:** demo-remediator-main/apps/sample-app/deployment.yaml
**Explanation:** The original deployment had a container with the SYS_ADMIN capability added, which violates security best practices. The remediation removes the 'add' section with SYS_ADMIN capability and replaces it with a 'drop' section that drops ALL capabilities. This ensures the container runs with minimal privileges, improving the security posture of the deployment. No other violations were found in the resource definition.