### PR TITLE
fix: Policy violation remediation in demo-remediator-main/apps/nginx/deployment.yaml

### DIFF
--- a/demo-remediator-main/apps/nginx/deployment.yaml
+++ b/demo-remediator-main/apps/nginx/deployment.yaml
@@ -4,7 +4,6 @@ metadata:
   name: nginx
   labels:
     app: nginx
-  annotations: {}
 spec:
   replicas: 1
   selector:

--- a/demo-remediator-main/apps/nginx/deployment.yaml
+++ b/demo-remediator-main/apps/nginx/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: nginx
   labels:
     app: nginx
+  annotations: {}
 spec:
   replicas: 1
   selector:

--- a/demo-remediator-main/apps/nginx/deployment.yaml
+++ b/demo-remediator-main/apps/nginx/deployment.yaml
@@ -4,8 +4,6 @@ metadata:
   name: nginx
   labels:
     app: nginx
-  annotations:
-    container.apparmor.security.beta.kubernetes.io/nginx: unconfined
 spec:
   replicas: 1
   selector:
@@ -18,15 +16,16 @@ spec:
     spec:
       volumes:
       - name: host-vol
-        hostPath:
-          path: /etc
+        emptyDir: {}
       containers:
       - name: nginx
         image: nginx:latest
         ports:
         - containerPort: 80
         securityContext:
-          privileged: true
-          capabilities:
-            add:
-            - SYS_ADMIN
+          privileged: false
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 1000
+          seccompProfile:
+            type: RuntimeDefault

--- a/demo-remediator-main/apps/nginx/deployment.yaml
+++ b/demo-remediator-main/apps/nginx/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: nginx
   labels:
     app: nginx
+  annotations: {}
 spec:
   replicas: 1
   selector:
@@ -14,6 +15,9 @@ spec:
       labels:
         app: nginx
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
       volumes:
       - name: host-vol
         emptyDir: {}
@@ -27,5 +31,3 @@ spec:
           allowPrivilegeEscalation: false
           runAsNonRoot: true
           runAsUser: 1000
-          seccompProfile:
-            type: RuntimeDefault


### PR DESCRIPTION
## Policy Violation Remediation

**File:** demo-remediator-main/apps/nginx/deployment.yaml
**Explanation:** The following changes were made to remediate the Deployment:

1. Removed the AppArmor 'unconfined' annotation which is a security risk
2. Added pod-level securityContext with runAsNonRoot: true and runAsUser: 1000 to enforce non-root execution
3. Replaced the hostPath volume with an emptyDir volume to eliminate host filesystem access
4. Modified the container securityContext to:
   - Set privileged: false (was true)
   - Remove the SYS_ADMIN capability
   - Add allowPrivilegeEscalation: false
   - Add runAsNonRoot: true and runAsUser: 1000 at container level

These changes ensure the Deployment runs with least privilege and follows security best practices. Note that the image tag 'latest' was not changed as per instructions, but using specific version tags is recommended for production deployments.