### PR TITLE
fix: Policy violation remediation in demo-remediator-main/apps/sample-app/deployment.yaml

### DIFF
--- a/demo-remediator-main/apps/sample-app/deployment.yaml
+++ b/demo-remediator-main/apps/sample-app/deployment.yaml
@@ -29,5 +29,5 @@ spec:
           seccompProfile:
             type: RuntimeDefault
           capabilities:
-            add:
-            - SYS_ADMIN
+            drop:
+            - ALL


### PR DESCRIPTION
## Policy Violation Remediation

**File:** demo-remediator-main/apps/sample-app/deployment.yaml
**Explanation:** The original deployment had a container with the SYS_ADMIN capability added, which violates security best practices. The patch removes the 'add: [SYS_ADMIN]' configuration and replaces it with 'drop: [ALL]' to ensure the container runs with minimal capabilities. This change ensures the deployment follows the principle of least privilege, which is a security best practice for containerized applications. No other violations were found in the deployment specification.