### PR TITLE
fix: Policy violation remediation in demo-remediator-main/apps/sample-app/deployment.yaml

### DIFF
--- a/demo-remediator-main/apps/sample-app/deployment.yaml
+++ b/demo-remediator-main/apps/sample-app/deployment.yaml
@@ -29,5 +29,5 @@ spec:
           seccompProfile:
             type: RuntimeDefault
           capabilities:
-            add:
-            - SYS_ADMIN
+            drop:
+            - ALL

--- a/demo-remediator-main/apps/sample-app/deployment.yaml
+++ b/demo-remediator-main/apps/sample-app/deployment.yaml
@@ -29,5 +29,6 @@ spec:
           seccompProfile:
             type: RuntimeDefault
           capabilities:
+            add:
             drop:
             - ALL


### PR DESCRIPTION
## Policy Violation Remediation

**File:** demo-remediator-main/apps/sample-app/deployment.yaml
**Explanation:** The remediation removes the 'SYS_ADMIN' capability from the 'add' section and replaces it with a 'drop: ["ALL"]' configuration. This change ensures the container follows the principle of least privilege by dropping all capabilities rather than adding potentially dangerous ones like SYS_ADMIN. The SYS_ADMIN capability is particularly powerful and can be used to bypass security controls, so removing it and dropping all capabilities is a security best practice. No other violations were found in the deployment specification as it already has appropriate security context settings like runAsNonRoot: true, allowPrivilegeEscalation: false, and a RuntimeDefault seccomp profile.