### PR TITLE
fix: Policy violation remediation in demo-remediator-main/apps/nginx/deployment.yaml

### DIFF
--- a/demo-remediator-main/apps/nginx/deployment.yaml
+++ b/demo-remediator-main/apps/nginx/deployment.yaml
@@ -20,13 +20,14 @@ spec:
       - name: host-vol
         hostPath:
           path: /etc
+      securityContext:
+        runAsNonRoot: true
       containers:
       - name: nginx
         image: nginx:latest
         ports:
         - containerPort: 80
         securityContext:
-          privileged: true
-          capabilities:
-            add:
-            - SYS_ADMIN
+          privileged: false
+          runAsNonRoot: true
+          capabilities: {}


### PR DESCRIPTION
## Policy Violation Remediation

**File:** demo-remediator-main/apps/nginx/deployment.yaml
**Explanation:** The following changes were made to remediate the Kyverno policy violations:

1. Added `securityContext.runAsNonRoot: true` at the pod level to comply with the 'require-run-as-nonroot' policy
2. Changed `securityContext.privileged: true` to `securityContext.privileged: false` to comply with the 'disallow-privileged-containers' policy
3. Added `securityContext.runAsNonRoot: true` at the container level for additional compliance with the 'require-run-as-nonroot' policy
4. Removed the SYS_ADMIN capability which is a privileged capability and generally considered insecure

Additional recommendations (not implemented):
1. Consider removing the AppArmor annotation that sets the profile to 'unconfined'
2. Consider using a specific version tag for the nginx image instead of 'latest'
3. The hostPath volume mount to /etc is potentially insecure and should be reconsidered if not absolutely necessary
4. Consider implementing a more restrictive security context with readOnlyRootFilesystem and allowPrivilegeEscalation set to false

### Authentication
This PR was created using pat authentication.