### PR TITLE
fix: Policy violation remediation in demo-remediator-main/apps/nginx/deployment.yaml

### DIFF
--- a/demo-remediator-main/apps/nginx/deployment.yaml
+++ b/demo-remediator-main/apps/nginx/deployment.yaml
@@ -4,6 +4,8 @@ metadata:
   name: nginx
   labels:
     app: nginx
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/nginx: unconfined
 spec:
   replicas: 1
   selector:

--- a/demo-remediator-main/apps/nginx/deployment.yaml
+++ b/demo-remediator-main/apps/nginx/deployment.yaml
@@ -4,8 +4,6 @@ metadata:
   name: nginx
   labels:
     app: nginx
-  annotations:
-    container.apparmor.security.beta.kubernetes.io/nginx: unconfined
 spec:
   replicas: 1
   selector:

--- a/demo-remediator-main/apps/nginx/deployment.yaml
+++ b/demo-remediator-main/apps/nginx/deployment.yaml
@@ -16,6 +16,8 @@ spec:
       labels:
         app: nginx
     spec:
+      securityContext:
+        runAsNonRoot: true
       volumes:
       - name: host-vol
         hostPath:
@@ -26,7 +28,8 @@ spec:
         ports:
         - containerPort: 80
         securityContext:
-          privileged: true
+          privileged: false
+          runAsNonRoot: true
           capabilities:
             add:
             - SYS_ADMIN

--- a/demo-remediator-main/apps/nginx/deployment.yaml
+++ b/demo-remediator-main/apps/nginx/deployment.yaml
@@ -4,8 +4,6 @@ metadata:
   name: nginx
   labels:
     app: nginx
-  annotations:
-    container.apparmor.security.beta.kubernetes.io/nginx: unconfined
 spec:
   replicas: 1
   selector:
@@ -16,12 +14,12 @@ spec:
       labels:
         app: nginx
     spec:
-      securityContext:
-        runAsNonRoot: true
       volumes:
       - name: host-vol
         hostPath:
           path: /etc
+      securityContext:
+        runAsNonRoot: true
       containers:
       - name: nginx
         image: nginx:latest
@@ -30,6 +28,3 @@ spec:
         securityContext:
           privileged: false
           runAsNonRoot: true
-          capabilities:
-            add:
-            - SYS_ADMIN


### PR DESCRIPTION
fix: Update policy violation remediation

The following changes were made to remediate policy violations:

1. Removed the AppArmor annotation that sets an 'unconfined' profile, which is a security concern.
2. Added pod-level securityContext with runAsNonRoot: true to satisfy the require-run-as-nonroot policy.
3. Modified the container's securityContext to:
   - Set privileged: false (was previously true) to satisfy the disallow-privileged-containers policy
   - Added runAsNonRoot: true to ensure the container runs as a non-root user
   - Removed the SYS_ADMIN capability which is a security risk

Additional recommendations (not implemented):
- Consider implementing a more restrictive security context with seccomp profiles
- The hostPath volume (/etc) still presents a security concern and should be replaced with a more secure volume type when possible
- Use a specific image tag instead of 'latest' for better reproducibility and security