### PR TITLE
fix: Policy violation remediation in demo-remediator-main/apps/nginx/deployment.yaml

### DIFF
--- a/demo-remediator-main/apps/nginx/deployment.yaml
+++ b/demo-remediator-main/apps/nginx/deployment.yaml
@@ -4,6 +4,8 @@ metadata:
   name: nginx
   labels:
     app: nginx
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/nginx: unconfined
 spec:
   replicas: 1
   selector:

--- a/demo-remediator-main/apps/nginx/deployment.yaml
+++ b/demo-remediator-main/apps/nginx/deployment.yaml
@@ -4,8 +4,6 @@ metadata:
   name: nginx
   labels:
     app: nginx
-  annotations:
-    container.apparmor.security.beta.kubernetes.io/nginx: unconfined
 spec:
   replicas: 1
   selector:

--- a/demo-remediator-main/apps/nginx/deployment.yaml
+++ b/demo-remediator-main/apps/nginx/deployment.yaml
@@ -16,6 +16,8 @@ spec:
       labels:
         app: nginx
     spec:
+      securityContext:
+        runAsNonRoot: true
       volumes:
       - name: host-vol
         hostPath:
@@ -26,7 +28,8 @@ spec:
         ports:
         - containerPort: 80
         securityContext:
-          privileged: true
+          privileged: false
+          runAsNonRoot: true
           capabilities:
             add:
             - SYS_ADMIN

--- a/demo-remediator-main/apps/nginx/deployment.yaml
+++ b/demo-remediator-main/apps/nginx/deployment.yaml
@@ -4,6 +4,8 @@ metadata:
   name: nginx
   labels:
     app: nginx
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/nginx: unconfined
 spec:
   replicas: 1
   selector:
@@ -14,17 +16,19 @@ spec:
       labels:
         app: nginx
     spec:
+      securityContext:
+        runAsNonRoot: true
       volumes:
       - name: host-vol
         hostPath:
           path: /etc
-      securityContext:
-        runAsNonRoot: true
       containers:
       - name: nginx
         image: nginx:latest
         ports:
         - containerPort: 80
         securityContext:
+          privileged: true
           privileged: false
           runAsNonRoot: true
+          capabilities: {}

--- a/demo-remediator-main/apps/nginx/deployment.yaml
+++ b/demo-remediator-main/apps/nginx/deployment.yaml
@@ -4,8 +4,6 @@ metadata:
   name: nginx
   labels:
     app: nginx
-  annotations:
-    container.apparmor.security.beta.kubernetes.io/nginx: unconfined
 spec:
   replicas: 1
   selector:
@@ -16,12 +14,12 @@ spec:
       labels:
         app: nginx
     spec:
-      securityContext:
-        runAsNonRoot: true
       volumes:
       - name: host-vol
         hostPath:
           path: /etc
+      securityContext:
+        runAsNonRoot: true
       containers:
       - name: nginx
         image: nginx:latest
@@ -30,6 +28,3 @@ spec:
         securityContext:
           privileged: false
           runAsNonRoot: true
-          capabilities:
-            add:
-            - SYS_ADMIN


### PR DESCRIPTION
## Policy Violation Remediation

**File:** demo-remediator-main/apps/nginx/deployment.yaml
**Explanation:** The deployment has been modified to address two Kyverno policy violations:

1. For the 'disallow-privileged-containers' policy violation:
   - Set 'privileged: false' in the container's security context to disable privileged mode
   - Removed the SYS_ADMIN capability which is typically associated with privileged access

2. For the 'require-run-as-nonroot' policy violation:
   - Added 'runAsNonRoot: true' at both the pod level (spec.template.spec.securityContext) and container level

Additional security improvements (not implemented) could include:
- Removing the hostPath volume which gives access to /etc on the host filesystem
- Setting specific user/group IDs with runAsUser/runAsGroup
- Using a specific image tag instead of 'latest'
- Adding additional security context restrictions like allowPrivilegeEscalation: false
- Removing the unconfined AppArmor annotation

### Authentication
This PR was created using pat authentication.